### PR TITLE
Fix memory usage of flatten

### DIFF
--- a/src/backlight/__init__.py
+++ b/src/backlight/__init__.py
@@ -1,4 +1,4 @@
 __author__ = "AlpacaJapan Co., Ltd."
-__version__ = "0.1.4"
-__release__ = "0.1.4"
+__version__ = "0.1.5"
+__release__ = "0.1.5"
 __license__ = "MIT"

--- a/src/backlight/trades/trades.py
+++ b/src/backlight/trades/trades.py
@@ -66,6 +66,6 @@ def flatten(trades: Trades) -> Trade:
     symbol = trades[0].symbol
     assert all([t.symbol == symbol for t in trades])
 
-    amounts = pd.concat([t.amount for t in trades], axis=1, join="outer")
-    amount = amounts.sum(axis=1, skipna=True).sort_index()
+    amounts = pd.concat([t.amount for t in trades], axis=0)
+    amount = amounts.groupby(amounts.index).sum().sort_index()
     return from_series(amount, symbol)


### PR DESCRIPTION
I am very fool to do such a thing... I fixed it.

It will reduce meory usage from `O(N^2)` to `O(N)`, where N is time step size. Also, it will reduce time of calculation.