### PR TITLE
Add tests using pypy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,19 +16,7 @@ jobs:
           name: unittest
           command: |
             make unittest
-  test_pypy:
-    docker:
-      - image: circleci/pypy:4.0.1
-    working_directory: ~/project
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: 18.05.0-ce
-          reusable: false
-      - run:
-          name: unittest
-          command: |
-            make unittest
+            make unittest_pypy
   black:
     docker:
       - image: circleci/python:3.6
@@ -62,5 +50,4 @@ workflows:
     jobs:
       - black
       - test
-      - test_pypy
       - mypy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,19 @@ jobs:
           name: unittest
           command: |
             make unittest
+  test_pypy:
+    docker:
+      - image: pypy:3.6
+    working_directory: ~/project
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 18.05.0-ce
+          reusable: false
+      - run:
+          name: unittest
+          command: |
+            make unittest
   black:
     docker:
       - image: circleci/python:3.6
@@ -49,4 +62,5 @@ workflows:
     jobs:
       - black
       - test
+      - test_pypy
       - mypy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             make unittest
   test_pypy:
     docker:
-      - image: pypy:3.6
+      - image: jamiehewland/alpine-pypy:3.5-7-alpine3.9
     working_directory: ~/project
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             make unittest
   test_pypy:
     docker:
-      - image: jamiehewland/alpine-pypy:3.5-7-alpine3.9
+      - image: circleci/pypy:4.0.1
     working_directory: ~/project
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ _install_pypy:
 	docker run $(DOCKER_OPTS) \
 		-it --volumes-from mysrc \
 		$(IMAGE_NAME) \
-		bash -c 'apt-get update -y; apt-get install pypy3 -y'
+		bash -c 'add-apt-repository ppa:pypy/ppa; apt-get update -y; apt-get install pypy3 -y'
 
 mypy: _mount_src
 	docker pull alpacadb/alpaca-containers:mypy-v0.0.1

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ _install_pypy:
 	docker run $(DOCKER_OPTS) \
 		-it --volumes-from mysrc \
 		$(IMAGE_NAME) \
-		bash -c 'sudo apt-get update -y; sudo apt-get install pypy3 -y'
+		bash -c 'apt-get update -y; apt-get install pypy3 -y'
 
 mypy: _mount_src
 	docker pull alpacadb/alpaca-containers:mypy-v0.0.1

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,6 @@ _mount_src:
 	docker create -v /project --name mysrc alpine:3.4 /bin/true
 	docker cp $(PROJECT_ROOT)/. mysrc:/project/
 
-_install_pypy:
-	docker run $(DOCKER_OPTS) \
-		-it --volumes-from mysrc \
-		$(IMAGE_NAME) \
-		bash -c 'add-apt-repository -y ppa:pypy/ppa; apt-get update -y; apt-get install pypy3 -y'
-
 mypy: _mount_src
 	docker pull alpacadb/alpaca-containers:mypy-v0.0.1
 	docker run -it -w /project --volumes-from mysrc \
@@ -59,11 +53,11 @@ unittest: _mount_src
 		$(IMAGE_NAME) \
 		bash -c 'PYTHONIOENCODING=UTF-8 py.test $(UNIT_TEST_OPTS)'
 
-unittest_pypy: _mount_src _install_pypy
+unittest_pypy: _mount_src
 	docker run $(DOCKER_OPTS) \
 		-it --volumes-from mysrc \
 		$(IMAGE_NAME) \
-		bash -c 'PYTHONIOENCODING=UTF-8 pypy3 -m pytest $(UNIT_TEST_OPTS)'
+		bash -c 'add-apt-repository -y ppa:pypy/ppa && apt-get update -qq -y && apt-get install pypy3 -y && PYTHONIOENCODING=UTF-8 pypy3 -m pytest $(UNIT_TEST_OPTS)'
 
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ _mount_src:
 	docker create -v /project --name mysrc alpine:3.4 /bin/true
 	docker cp $(PROJECT_ROOT)/. mysrc:/project/
 
+_install_pypy:
+	docker run $(DOCKER_OPTS) \
+		-it --volumes-from mysrc \
+		$(IMAGE_NAME) \
+		bash -c 'sudo apt-get update -y; sudo apt-get install pypy3 -y'
+
 mypy: _mount_src
 	docker pull alpacadb/alpaca-containers:mypy-v0.0.1
 	docker run -it -w /project --volumes-from mysrc \
@@ -53,11 +59,11 @@ unittest: _mount_src
 		$(IMAGE_NAME) \
 		bash -c 'PYTHONIOENCODING=UTF-8 py.test $(UNIT_TEST_OPTS)'
 
-unittest_pypy: _mount_src
+unittest_pypy: _mount_src _install_pypy
 	docker run $(DOCKER_OPTS) \
 		-it --volumes-from mysrc \
 		$(IMAGE_NAME) \
-		bash -c 'PYTHONIOENCODING=UTF-8 pypy -m pytest $(UNIT_TEST_OPTS)'
+		bash -c 'PYTHONIOENCODING=UTF-8 pypy3 -m pytest $(UNIT_TEST_OPTS)'
 
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ _install_pypy:
 	docker run $(DOCKER_OPTS) \
 		-it --volumes-from mysrc \
 		$(IMAGE_NAME) \
-		bash -c 'add-apt-repository ppa:pypy/ppa; apt-get update -y; apt-get install pypy3 -y'
+		bash -c 'add-apt-repository -y ppa:pypy/ppa; apt-get update -y; apt-get install pypy3 -y'
 
 mypy: _mount_src
 	docker pull alpacadb/alpaca-containers:mypy-v0.0.1

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ unittest: _mount_src
 		$(IMAGE_NAME) \
 		bash -c 'PYTHONIOENCODING=UTF-8 py.test $(UNIT_TEST_OPTS)'
 
+unittest_pypy: _mount_src
+	docker run $(DOCKER_OPTS) \
+		-it --volumes-from mysrc \
+		$(IMAGE_NAME) \
+		bash -c 'PYTHONIOENCODING=UTF-8 pypy -m pytest $(UNIT_TEST_OPTS)'
+
 
 build:
 	python setup.py build


### PR DESCRIPTION
Goals:
* Run the tests using [pypy](https://pypy.org/download.html)

Tried:
- [x] Use circleci image containing pypy: None
- [x] Build a standard pypy image on circleci: Failed because of limited alpine-linux support, see [relevant issue](https://github.com/docker-library/pypy/issues/5)
- [x] Using [patched pypy](https://github.com/JayH5/docker-alpine-pypy)
- [x] Installing pypy after launch using ppa:
    - Work but then would need to re-install all dependencies
- [ ] (Other potential ideas)…