### PR TITLE
Same symbols Portfolio

### DIFF
--- a/src/backlight/portfolio/portfolio.py
+++ b/src/backlight/portfolio/portfolio.py
@@ -80,13 +80,54 @@ def construct_portfolio(
     for (trade, lot) in zip(trades, lot_size):
         trade["amount"] *= lot
 
+    """
+    There is an issue here :
+    - We have two solutions : we fusion the trades of same symbols before calculating the positions or
+    we calculate the positions and then fusion them for same symbols.
+    - In the first case, the problem of the _id column risks to be heavy to solve as much in term of code as
+    in term of computation time. Morever, here, the trades and the market datas are assumed to be ranked in 
+    the same order (regarding of the symbols). If its not the case its impossible to know it. Same for principal.
+    - In the second case, we need to duplicate the market and principal columns to fit the size of the trades. 
+    It will be time and memory consuming.
+    
+    I implemented the 2nd one at the moment.
+    """
+
+    new_mkt = [symbols2mkt.get(t.symbol) for t in trades]
+    assert len(principal) == len(trades)
+    assert len(lot_size) == len(trades)
+
     # Construct positions and return Portfolio
     positions = Parallel(n_jobs=-1, max_nbytes=None)(
         [
             delayed(calc_positions)(trade, market, principal=principal_per_asset)
-            for (trade, market, principal_per_asset) in zip(trades, mkt, principal)
+            for (trade, market, principal_per_asset) in zip(trades, new_mkt, principal)
         ]
     )
+
+    # Here are the modifications done on positions after treatment.
+    symbols = [p.symbol for p in positions]
+    if len(set(symbols)) != len(symbols):
+        unique_positions = []
+        for position in positions:
+            s = position.symbol
+            if symbols.count(s) > 1:
+                df = pd.DataFrame(
+                    data=np.array([p.values for p in positions if p.symbol == s]).sum(
+                        axis=0
+                    ),
+                    index=position.index,
+                    columns=position.columns,
+                )
+                pos = Positions(df)
+                pos.symbol = s
+                unique_positions.append(pos)
+                for _ in range(symbols.count(s)):
+                    symbols.remove(s)
+            elif symbols.count(position.symbol) == 1:
+                unique_positions.append(position)
+        positions = unique_positions
+
     return Portfolio(positions)
 
 

--- a/src/backlight/positions/positions.py
+++ b/src/backlight/positions/positions.py
@@ -82,3 +82,17 @@ def calc_positions(
     pos.reset_cols()
     pos.symbol = trades.symbol
     return pos
+
+
+def position_from_dataframe(df: pd.DataFrame, symbol: str) -> Positions:
+    """
+    Create Positions from dataframe and symbol.
+    
+    Args:
+        df: DataFrame with the content of the future Positions.
+        symbol: The Positions symbol.
+    """
+    pos = Positions(df)
+    pos.reset_cols()
+    pos.symbol = symbol
+    return pos

--- a/src/backlight/positions/positions.py
+++ b/src/backlight/positions/positions.py
@@ -84,7 +84,7 @@ def calc_positions(
     return pos
 
 
-def position_from_dataframe(df: pd.DataFrame, symbol: str) -> Positions:
+def from_dataframe(df: pd.DataFrame, symbol: str) -> Positions:
     """
     Create Positions from dataframe and symbol.
     

--- a/tests/portfolio/test_portfolio.py
+++ b/tests/portfolio/test_portfolio.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 from backlight.portfolio.portfolio import construct_portfolio as module
 from backlight.portfolio.portfolio import _fusion_positions
-from backlight.positions.positions import position_from_dataframe
+import backlight.positions.positions
 
 import backlight
 
@@ -155,7 +155,7 @@ def test_fusion_positions():
         columns=columns,
     )
     symbol = "usdjpy"
-    positions_list.append(position_from_dataframe(df, symbol))
+    positions_list.append(backlight.positions.positions.from_dataframe(df, symbol))
 
     df = pd.DataFrame(
         data=data,
@@ -163,7 +163,7 @@ def test_fusion_positions():
         columns=columns,
     )
     symbol = "usdjpy"
-    positions_list.append(position_from_dataframe(df, symbol))
+    positions_list.append(backlight.positions.positions.from_dataframe(df, symbol))
 
     df = pd.DataFrame(
         data=data,
@@ -171,7 +171,7 @@ def test_fusion_positions():
         columns=columns,
     )
     symbol = "eurjpy"
-    positions_list.append(position_from_dataframe(df, symbol))
+    positions_list.append(backlight.positions.positions.from_dataframe(df, symbol))
 
     fusioned = _fusion_positions(positions_list)
 

--- a/tests/portfolio/test_portfolio.py
+++ b/tests/portfolio/test_portfolio.py
@@ -37,6 +37,7 @@ def trades():
 
     trades.append(make_trades("usdjpy", [trade], [ids]))
     trades.append(make_trades("eurjpy", [trade], [ids]))
+    trades.append(make_trades("usdjpy", [trade], [ids]))
     return trades
 
 
@@ -60,17 +61,26 @@ def markets():
         columns=["mid"],
     )
     markets.append(backlight.datasource.from_dataframe(df, symbol))
+
+    symbol = "usdjpy"
+    periods = 10
+    df = pd.DataFrame(
+        index=pd.date_range(start="2018-06-06", freq="1min", periods=periods),
+        data=np.arange(periods)[:, None],
+        columns=["mid"],
+    )
+    markets.append(backlight.datasource.from_dataframe(df, symbol))
     return markets
 
 
 @pytest.fixture
 def principal():
-    return [10, 10]
+    return [10, 10, 10]
 
 
 @pytest.fixture
 def lot_size():
-    return [2, 2]
+    return [2, 2, 2]
 
 
 def test_construct_portfolio(trades, markets, principal, lot_size):
@@ -92,20 +102,6 @@ def test_construct_portfolio(trades, markets, principal, lot_size):
 
     data1 = [
         [0.0, 0.0, 10.0],
-        [2.0, 0.0, 10.0],
-        [0.0, 1.0, 12.0],
-        [-2.0, 2.0, 16.0],
-        [2.0, 3.0, 4.0],
-        [4.0, 4.0, -4.0],
-        [0.0, 5.0, 16.0],
-        [-4.0, 6.0, 40.0],
-        [-2.0, 7.0, 26.0],
-        [0.0, 8.0, 10.0],
-        [0.0, 9.0, 10.0],
-    ]
-
-    data2 = [
-        [0.0, 0.0, 10.0],
         [2.0, 10.0, -10.0],
         [0.0, 9.0, 8.0],
         [-2.0, 8.0, 24.0],
@@ -116,6 +112,20 @@ def test_construct_portfolio(trades, markets, principal, lot_size):
         [-2.0, 3.0, 14.0],
         [0.0, 2.0, 10.0],
         [0.0, 1.0, 10.0],
+    ]
+
+    data2 = [
+        [0.0, 0.0, 20.0],
+        [4.0, 0.0, 20.0],
+        [0.0, 2.0, 24.0],
+        [-4.0, 4.0, 32.0],
+        [4.0, 6.0, 8.0],
+        [8.0, 8.0, -8.0],
+        [0.0, 10.0, 32.0],
+        [-8.0, 12.0, 80.0],
+        [-4.0, 14.0, 52.0],
+        [0.0, 16.0, 20.0],
+        [0.0, 18.0, 20.0],
     ]
 
     data = [data1, data2]

--- a/tests/portfolio/test_portfolio.py
+++ b/tests/portfolio/test_portfolio.py
@@ -7,7 +7,6 @@ import backlight.positions.positions
 
 
 import backlight
-from backlight.portfolio.portfolio import construct_portfolio as module
 from backlight.trades.trades import make_trades
 from backlight.positions.positions import Positions
 from backlight.portfolio.portfolio import Portfolio, calculate_pl
@@ -144,6 +143,7 @@ def test_construct_portfolio(trades, markets, principal, lot_size):
         )
         assert ((expected == position).all()).all()
 
+
 def test_fusion_positions():
 
     periods = 3
@@ -195,6 +195,7 @@ def test_fusion_positions():
 
     for exp, fus in zip(expected, fusioned):
         assert exp.all().all() == fus.all().all()
+
 
 @pytest.fixture
 def mid_markets():


### PR DESCRIPTION
I proposed a first solution for the creation of a Portfolio from same symbol's trades. I have an issue that I want to discuss about that I put in a comment. Here is the content : 
- We have two solutions : we fusion the trades of same symbols before calculating the positions or we calculate the positions and then fusion them for same symbols.
- In the first case, the problem of the _id column risks to be heavy to solve as much in term of code as in term of computation time. Morever, here, the trades and the market datas are assumed to be ranked in the same order (regarding of the symbols). If its not the case its impossible to know it. Same for principal.
- In the second case, we need to duplicate the market and principal columns to fit the size of the trades. It will be time and memory consuming.

I implemented the 2nd one to evaluate it.