### PR TITLE
Accelerate exit_by_max_holding_time function for our specific case

### DIFF
--- a/src/backlight/strategies/exit.py
+++ b/src/backlight/strategies/exit.py
@@ -26,25 +26,23 @@ def _concat(mkt: MarketData, sig: Optional[Signal]) -> pd.DataFrame:
 def _exit_transaction(
     df: pd.DataFrame,
     trade: pd.Series,
-    exit_condition: Callable[[pd.DataFrame, pd.Series], pd.Series],
+    exit_condition: Callable[[pd.DataFrame, pd.Series, pd.Timestamp], bool],
 ) -> Transaction:
-    exit_indices = df[exit_condition(df, trade)].index
-    if exit_indices.empty:
-        exit_index = df.index[-1]
-    else:
-        exit_index = exit_indices[0]
-    return Transaction(timestamp=exit_index, amount=-trade.sum())
+    for indx in df.index:
+        if exit_condition(df, trade, indx):
+            return Transaction(timestamp=indx, amount=-trade.sum())
+    return Transaction(timestamp=df.index[-1], amount=-trade.sum())
 
 
-def _no_exit_condition(df: pd.DataFrame, trade: pd.Series) -> pd.Series:
-    return pd.Series(index=df.index, data=False)
+def _no_exit_condition(df: pd.DataFrame, trade: pd.Series, indx: pd.Timestamp) -> bool:
+    return False
 
 
 def exit(
     mkt: MarketData,
     sig: Optional[Signal],
     entries: Trades,
-    exit_condition: Callable[[pd.DataFrame, pd.Series], pd.Series],
+    exit_condition: Callable[[pd.DataFrame, pd.Series, pd.Timestamp], bool],
 ) -> Trades:
     """Exit trade when satisfying condition.
 
@@ -63,7 +61,7 @@ def exit(
     def _exit(
         trades: Trades,
         df: pd.DataFrame,
-        exit_condition: Callable[[pd.DataFrame, pd.Series], pd.Series],
+        exit_condition: Callable[[pd.DataFrame, pd.Series, pd.Timestamp], bool],
     ) -> pd.Series:
 
         indices = []  # type: List[pd.Timestamp]
@@ -94,7 +92,7 @@ def exit_by_max_holding_time(
     sig: Optional[Signal],
     entries: Trades,
     max_holding_time: pd.Timedelta,
-    exit_condition: Callable[[pd.DataFrame, pd.Series], pd.Series],
+    exit_condition: Callable[[pd.DataFrame, pd.Series, pd.Timestamp], bool],
 ) -> Trades:
     """Exit trade at max holding time or satisfying condition.
 
@@ -114,7 +112,7 @@ def exit_by_max_holding_time(
         trades: Trades,
         df: pd.DataFrame,
         max_holding_time: pd.Timedelta,
-        exit_condition: Callable[[pd.DataFrame, pd.Series], pd.Series],
+        exit_condition: Callable[[pd.DataFrame, pd.Series, pd.Timestamp], bool],
     ) -> Trades:
 
         indices = []  # type: List[pd.Timestamp]
@@ -125,29 +123,15 @@ def exit_by_max_holding_time(
                 continue
 
             idx = trade.index[0]
-            #             df_exit = df[(idx <= df.index) & (df.index <= idx + max_holding_time)]
-            #             transaction = _exit_transaction(df_exit, trade, exit_condition)
 
-            #             indices.append(transaction.timestamp)
-            #             exits.append((transaction.amount, i))
-
-            freq = df.index[1] - df.index[0]
             start = max(idx, df.index[0])
             end = min(idx + max_holding_time, df.index[-1])
 
-            for indx in pd.date_range(start=start, end=end, freq=freq):
-                # Here is the line which will not work for other functions. I suggest to replace it by something like :
-                # if exit_condition(df, trade, indx) :
-                # And modifying all the funtions accordingly.
-                if (
-                    TernaryDirection(df["pred"].at[start]).value
-                    * (df["up"].at[indx] - df["down"].at[indx])
-                    <= 0.0
-                ):
-                    break
+            df_exit = df.loc[start:end]
+            transaction = _exit_transaction(df_exit, trade, exit_condition)
 
-            indices.append(indx)
-            exits.append((-trade.sum(), i))
+            indices.append(transaction.timestamp)
+            exits.append((transaction.amount, i))
 
         df = pd.DataFrame(index=indices, data=exits, columns=["amount", "_id"])
         return from_dataframe(df, symbol)
@@ -195,14 +179,13 @@ def exit_at_opposite_signals(
     """
 
     def _exit_at_opposite_signals_condition(
-        df: pd.DataFrame, opposite_signals_dict: dict
-    ) -> pd.Series:
-        current_signal = TernaryDirection(df["pred"][0])
-        opposite_signals = opposite_signals_dict[current_signal]
-        return df["pred"].isin(opposite_signals)
+        df: pd.DataFrame, opposite_signals_dict: dict, indx: pd.Timestamp
+    ) -> bool:
+        opposite_signals = opposite_signals_dict[TernaryDirection(df["pred"][0])]
+        return df["pred"].at[indx] in opposite_signals
 
-    def _exit_condition(df: pd.DataFrame, trade: pd.Series) -> pd.Series:
-        return _exit_at_opposite_signals_condition(df, opposite_signals_dict)
+    def _exit_condition(df: pd.DataFrame, trade: pd.Series, indx: pd.Timestamp) -> bool:
+        return _exit_at_opposite_signals_condition(df, opposite_signals_dict, indx)
 
     return exit_by_max_holding_time(
         mkt, sig, entries, max_holding_time, _exit_condition
@@ -223,13 +206,14 @@ def exit_by_expectation(
         Trades
     """
 
-    def _exit_by_expectation_condition(df: pd.DataFrame, trade: pd.Series) -> pd.Series:
-        current_signal = TernaryDirection(df["pred"][0])
-        v = np.array([1.0, 0.0, -1.0])
-        expectation = np.dot(df[["up", "neutral", "down"]].values, v)
-        expectation = current_signal.value * expectation
-        sign = expectation < 0.0
-        return pd.Series(index=df.index, data=sign)
+    def _exit_by_expectation_condition(
+        df: pd.DataFrame, trade: pd.Series, indx: pd.Timestamp
+    ) -> bool:
+        return (
+            TernaryDirection(df["pred"].at[df.index[0]]).value
+            * (df["up"].at[indx] - df["down"].at[indx])
+            < 0.0
+        )
 
     return exit_by_max_holding_time(
         mkt, sig, entries, max_holding_time, _exit_by_expectation_condition
@@ -258,20 +242,28 @@ def exit_by_trailing_stop(
     assert initial_stop >= 0.0
     assert trailing_stop >= 0.0
 
-    def _exit_by_trailing_stop(df: pd.DataFrame, trade: pd.Series) -> pd.Series:
-        prices = df.mid
+    def _exit_by_trailing_stop(
+        df: pd.DataFrame, trade: pd.Series, indx: pd.Timestamp
+    ) -> bool:
 
         amount = trade.sum()
-        entry_price = prices.iloc[0]
-        pl_per_amount = np.sign(amount) * (prices - entry_price)
-        is_initial_stop = pl_per_amount <= -initial_stop
+        entry_price = df.mid.iat[0]
 
+        if np.sign(amount) * (df.mid.at[indx] - entry_price) <= -initial_stop:
+            return True
+
+        prices = df.mid
+        pl_per_amount = np.sign(amount) * (prices - entry_price)
         historical_max_pl = pl_per_amount.cummax()
         drawdown = historical_max_pl - pl_per_amount
-        is_trailing_stop = (historical_max_pl >= trailing_stop) & (
-            drawdown >= trailing_stop
-        )
-        return is_initial_stop | is_trailing_stop
+
+        if (
+            historical_max_pl.at[indx] >= trailing_stop
+            and drawdown.at[indx] >= trailing_stop
+        ):
+            return True
+
+        return False
 
     return exit(mkt, None, entries, _exit_by_trailing_stop)
 
@@ -287,16 +279,18 @@ def exit_at_loss_and_gain(
 
     df = _concat(mkt, sig)
 
-    def _exit_at_loss_and_gain(df: pd.DataFrame, trade: pd.Series) -> pd.Series:
-        prices = df.mid
+    def _exit_at_loss_and_gain(
+        df: pd.DataFrame, trade: pd.Series, indx: pd.Timestamp
+    ) -> bool:
 
         amount = trade.sum()
-        entry_price = prices.iloc[0]
+        entry_price = df.mid.iat[0]
+        value = np.sign(amount) * (df.mid.at[indx] - entry_price)
 
-        pl_per_amount = np.sign(amount) * (prices - entry_price)
-        is_stop_loss = pl_per_amount <= -loss_threshold
-        is_take_gain = pl_per_amount >= gain_threshold
-        return is_stop_loss | is_take_gain
+        if value <= -loss_threshold or value >= gain_threshold:
+            return True
+
+        return False
 
     return exit_by_max_holding_time(
         mkt, None, entries, max_holding_time, _exit_at_loss_and_gain

--- a/src/backlight/strategies/exit.py
+++ b/src/backlight/strategies/exit.py
@@ -184,7 +184,9 @@ def exit_at_opposite_signals(
         opposite_signals = opposite_signals_dict[TernaryDirection(df["pred"][0])]
         return df["pred"].at[index] in opposite_signals
 
-    def _exit_condition(df: pd.DataFrame, trade: pd.Series, index: pd.Timestamp) -> bool:
+    def _exit_condition(
+        df: pd.DataFrame, trade: pd.Series, index: pd.Timestamp
+    ) -> bool:
         return _exit_at_opposite_signals_condition(df, opposite_signals_dict, index)
 
     return exit_by_max_holding_time(


### PR DESCRIPTION
I modified the exit_by_max_holding_time function so it is twice faster when you use it by exit_by_expectation function. 
Tests are failing because the function is used in many different functions (exit_at_opposite_signals, exit_by_expectation, exit_at_loss_and_gain just in the exit.py file). I suggested to modify these functions so that they do not take a whole DataFrame but just a single element and do not return a TimeSeries but a boolean.
If you want to make test about the speed I can setup a more flexible implementation for easier use. From now, just call the exit_by_expectation function, the results were the same on my tests.