### PR TITLE
Improve trades.get_any performance

### DIFF
--- a/src/backlight/strategies/filter.py
+++ b/src/backlight/strategies/filter.py
@@ -61,7 +61,9 @@ def skip_entry_by_spread(
     return trades[~trades["_id"].isin(deleted_ids)]
 
 
-def get_in_set(trades: Trades, unit: str, container_set: tuple) -> Type["Trades"]:
+def filter_entry_by_time(
+    trades: Trades, unit: str, container_set: tuple
+) -> Type["Trades"]:
     """Filter trade which match conditions at least one element. 
         -> e.g. for container_set = [1,2] and unit = 'hour' Trades of hour 1 or 2 
             will be return.

--- a/src/backlight/trades/trades.py
+++ b/src/backlight/trades/trades.py
@@ -57,7 +57,8 @@ class Trades(pd.DataFrame):
         """Filter trade which match conditions at least one element.
 
         Args:
-            interval: The 
+            interval: The results will only contain elements of time in this interval
+            time: Can be 'hour', 'minute'... The results.time will be in the interval
 
         Returns:
             Trades.

--- a/src/backlight/trades/trades.py
+++ b/src/backlight/trades/trades.py
@@ -54,7 +54,7 @@ class Trades(pd.DataFrame):
         """
         return self.loc[self._id == trade_id, "amount"]
 
-    def get_any(self, interval: tuple, time: str) -> Type["Trades"]:
+    def get_any(self, interval: tuple = None, gap: str = None) -> Type["Trades"]:
         """Filter trade which match conditions at least one element.
 
         Args:
@@ -81,8 +81,8 @@ class Trades(pd.DataFrame):
             entry_index = sort.index[i]
             exit_index = sort.index[i + 1]
             if (
-                getattr(entry_index, time) in interval
-                or getattr(exit_index, time) in interval
+                getattr(entry_index, gap) in interval
+                or getattr(exit_index, gap) in interval
             ):
                 # This looks ugly but iloc is very slow compare to that. I don't get why.
                 df.at[j, "amount"] = sort.iat[i, 0]

--- a/src/backlight/trades/trades.py
+++ b/src/backlight/trades/trades.py
@@ -53,28 +53,38 @@ class Trades(pd.DataFrame):
             Trade of pd.Series.
         """
         return self.loc[self._id == trade_id, "amount"]
-    
-    
-    def get_any(self, key: Any) -> Type["Trades"]:
-        """Filter trade which match conditions at least one element.
+
+    def get_any(
+        self, key: Any = None, container_set: tuple = (), gap: str = "hour"
+    ) -> Type["Trades"]:
+        """Filter trade which match conditions at least one element. Using container_set and gap
+        makes function way faster than using key. 
 
         Args:
-            key: Same arguments with pd.DataFrame.__getitem__.
+            key: Same arguments with pd.DataFrame.__getitem__
+            container_set: The results will only contain elements of time in this set
+            time: Can be 'hour', 'minute'... The results.time will be in the set
+                -> e.g. for container_set = [1,2] and time = 'hour' Trades of hour 1 or 2 
+                will be return.
 
         Returns:
             Trades.
         """
+
+        assert container_set or key
+
+        if container_set:
+            return self.get_in_set(gap, container_set)
+
         filterd_ids = self[key].ids
         trades = [self.get_trade(i) for i in filterd_ids]
         return make_trades(self.symbol, trades, self.currency_unit, filterd_ids)
 
-
-    def get_any(self, key: Any = None, container_set: tuple = None, gap: str = None) -> Type["Trades"]:
-        """Filter trade which match conditions at least one element. Using container_set and gap
-        makes function way faster than using key.
-
+    def get_in_set(self, gap: str, container_set: tuple = ()) -> Type["Trades"]:
+        """Filter trade which match conditions at least one element. 
+            -> e.g. for container_set = [1,2] and time = 'hour' Trades of hour 1 or 2 
+                will be return.
         Args:
-            key: Same arguments with pd.DataFrame.__getitem__.
             container_set: The results will only contain elements of time in this set
             time: Can be 'hour', 'minute'... The results.time will be in the set
 
@@ -82,51 +92,35 @@ class Trades(pd.DataFrame):
             Trades.
         """
 
-        # The function is getting complicated to read, but its way faster.
-        # Also, I had to change the arguments, so it is less flexible. I can work on
-        # it more to think about a just middle.
-        
-        
-        if container_set != None and gap != None:
-            sort = self.sort_values("_id")
+        sort = self.sort_values("_id")
 
-            df = pd.DataFrame(
-                data=np.zeros((sort.shape[0], 3)), columns=["amount", "_id", "index"]
-            )
+        df = pd.DataFrame(
+            data=np.zeros((sort.shape[0], 3)), columns=["amount", "_id", "index"]
+        )
 
-            j = 0
+        j = 0
 
-            for i in range(0, sort.index.size, 2):
-                entry_index = sort.index[i]
-                exit_index = sort.index[i + 1]
-                if (
-                    getattr(entry_index, gap) in container_set
-                    or getattr(exit_index, gap) in container_set
-                ):
-                    # This looks ugly but iloc is very slow compare to that. I don't get why.
-                    df.at[j, "amount"] = sort.iat[i, 0]
-                    df.at[j + 1, "amount"] = sort.iat[i + 1, 0]
-                    df.at[j, "_id"] = sort.iat[i, 1]
-                    df.at[j + 1, "_id"] = sort.iat[i + 1, 1]
-                    df.at[j, "index"] = entry_index
-                    df.at[j + 1, "index"] = exit_index
+        for i in range(0, sort.index.size, 2):
+            entry_index = sort.index[i]
+            exit_index = sort.index[i + 1]
+            if (
+                getattr(entry_index, gap) in container_set
+                or getattr(exit_index, gap) in container_set
+            ):
+                # This code is faster than a iloc.
+                df.at[j, "amount"] = sort.iat[i, 0]
+                df.at[j + 1, "amount"] = sort.iat[i + 1, 0]
+                df.at[j, "_id"] = sort.iat[i, 1]
+                df.at[j + 1, "_id"] = sort.iat[i + 1, 1]
+                df.at[j, "index"] = entry_index
+                df.at[j + 1, "index"] = exit_index
 
-                    j += 2
+                j += 2
 
-            df = df.iloc[0:j, :].sort_values("index").set_index("index")
-            df.index.name = None
+        df = df.iloc[0:j, :].sort_values("index").set_index("index")
+        df.index.name = None
 
-            return from_dataframe(df, self.symbol, self.currency_unit)
-
-        elif key != None:
-            filterd_ids = self[key].ids
-            trades = [self.get_trade(i) for i in filterd_ids]
-            return make_trades(self.symbol, trades, self.currency_unit, filterd_ids)
-        
-        else:
-            raise("At least key or interval and gap have to be set to a value")
-            return None
-        
+        return from_dataframe(df, self.symbol, self.currency_unit)
 
     def get_all(self, key: Any) -> Type["Trades"]:
         """Filter trade which match conditions for all elements.

--- a/tests/strategies/test_filter.py
+++ b/tests/strategies/test_filter.py
@@ -81,36 +81,6 @@ def askbid(symbol, currency_unit):
 def trades(market, signal):
     max_holding_time = pd.Timedelta("3min")
     trades = simple_entry_and_exit(market, signal, max_holding_time)
-    """
-    expected = pd.DataFrame(
-        index=market.index,
-        data=[
-            [True, 1.0],  # 1.0
-            [True, -1.0],  # 0.0
-            [False, 0.0],  # 0.0
-            [True, 0.0],  # 0.0
-            [True, 2.0],  # 2.0
-            [True, -1.0],  # 1.0
-            [True, -2.0],  # -1.0
-            [True, -1.0],  # -2.0
-            [True, 1.0],  # -1.0
-            [True, 2.0],  # 1.0
-            [True, 1.0],  # 2.0
-            [True, 1.0],  # 3.0
-            [True, -2.0],  # 1.0
-            [True, -2.0],  # -1.0
-            [True, -2.0],  # -3.0
-            [True, 1.0],  # -2.0
-            [True, 1.0],  # -1.0
-            [True, 1.0],  # 0.0
-            [True, 1.0],  # 1.0
-            [True, 1.0],  # 2.0
-            [True, 1.0],  # 3.0
-            [True, -3.0],  # 0.0
-        ],
-        columns=["exist", "amount"],
-    )
-    """
     return trades
 
 
@@ -179,5 +149,46 @@ def test_skip_entry_by_spread(trades, askbid):
         ],
         columns=["exist", "amount"],
     )
-    print(limited.amount)
+
     assert (limited.amount == expected.amount[expected.exist]).all()
+
+
+def test_get_in_set(trades, symbol, currency_unit):
+    result = module.get_in_set(trades, "minute", [1, 3, 8, 12])
+    df = pd.DataFrame(
+        data=[
+            [1.0, 0.0],
+            [-1.0, 1.0],
+            [-1.0, 0.0],
+            [1.0, 2.0],
+            [1.0, 1.0],
+            [-1.0, 4.0],
+            [-1.0, 2.0],
+            [1.0, 4.0],
+            [1.0, 6.0],
+            [-1.0, 6.0],
+            [-1.0, 9.0],
+            [1.0, 9.0],
+        ],
+        index=pd.DatetimeIndex(
+            [
+                pd.Timestamp("2018-06-06 00:00:00"),
+                pd.Timestamp("2018-06-06 00:01:00"),
+                pd.Timestamp("2018-06-06 00:03:00"),
+                pd.Timestamp("2018-06-06 00:03:00"),
+                pd.Timestamp("2018-06-06 00:04:00"),
+                pd.Timestamp("2018-06-06 00:05:00"),
+                pd.Timestamp("2018-06-06 00:06:00"),
+                pd.Timestamp("2018-06-06 00:08:00"),
+                pd.Timestamp("2018-06-06 00:09:00"),
+                pd.Timestamp("2018-06-06 00:12:00"),
+                pd.Timestamp("2018-06-06 00:12:00"),
+                pd.Timestamp("2018-06-06 00:15:00"),
+            ]
+        ),
+        columns=["amount", "_id"],
+    )
+
+    expected = backlight.trades.trades.from_dataframe(df, symbol, currency_unit)
+
+    assert (result.all() == expected.all()).all()

--- a/tests/strategies/test_filter.py
+++ b/tests/strategies/test_filter.py
@@ -153,8 +153,8 @@ def test_skip_entry_by_spread(trades, askbid):
     assert (limited.amount == expected.amount[expected.exist]).all()
 
 
-def test_get_in_set(trades, symbol, currency_unit):
-    result = module.get_in_set(trades, "minute", [1, 3, 8, 12])
+def test_filter_entry_by_time(trades, symbol, currency_unit):
+    result = module.filter_entry_by_time(trades, "minute", [1, 3, 8, 12])
     df = pd.DataFrame(
         data=[
             [1.0, 0.0],

--- a/tests/trades/test_trades.py
+++ b/tests/trades/test_trades.py
@@ -49,7 +49,7 @@ def test_trades_get_any(trades):
         pd.Timestamp("2018-06-06 00:05:00"),
     ]
     expected = pd.Series(data=data, index=index, name="amount")
-    result = trades.get_any([0, 4, 5], "minute")
+    result = trades.get_any(container_set=[0, 4, 5], gap="minute")
     pd.testing.assert_series_equal(result.amount, expected)
 
 

--- a/tests/trades/test_trades.py
+++ b/tests/trades/test_trades.py
@@ -8,7 +8,7 @@ from backlight.asset.currency import Currency
 
 @pytest.fixture
 def symbol():
-    return "usdjpy"
+    return "USDJPY"
 
 
 @pytest.fixture
@@ -49,7 +49,7 @@ def test_trades_get_any(trades):
         pd.Timestamp("2018-06-06 00:05:00"),
     ]
     expected = pd.Series(data=data, index=index, name="amount")
-    result = trades.get_any(trades.index.minute.isin([0, 4, 5]))
+    result = trades.get_any([0, 4, 5], "minute")
     pd.testing.assert_series_equal(result.amount, expected)
 
 

--- a/tests/trades/test_trades.py
+++ b/tests/trades/test_trades.py
@@ -49,7 +49,8 @@ def test_trades_get_any(trades):
         pd.Timestamp("2018-06-06 00:05:00"),
     ]
     expected = pd.Series(data=data, index=index, name="amount")
-    result = trades.get_any(container_set=[0, 4, 5], gap="minute")
+    # result = trades.get_any(container_set=[0, 4, 5], gap="minute")
+    result = trades.get_any(trades.index.minute.isin([0, 4, 5]))
     pd.testing.assert_series_equal(result.amount, expected)
 
 


### PR DESCRIPTION
The function has changed a lot and looks more complicated and has different arguments now, but it is very faster for big amounts of datas, so its possible to run it on rokko. Please tell me if I should change anything. I use it for the experiments, maybe we can think about a definitive version of it.