### PR TITLE
Fix imprecisions in `equally_weighted_portfolio` results

### DIFF
--- a/src/backlight/metrics/evaluation_metrics.py
+++ b/src/backlight/metrics/evaluation_metrics.py
@@ -43,7 +43,9 @@ def calculate_sharpe(
     """
     value = positions_or_portfolio.value.resample(freq).first().dropna()
     previous_value = value.shift(periods=1)
-    log_return = np.log((value.values / previous_value.values)[1:])
+    pl = (value.values / previous_value.values)[1:]
+    pl = pl[pl > 0]
+    log_return = np.log(pl)
 
     days_in_year = pd.Timedelta("252D")
     annual_factor = math.sqrt(days_in_year / freq)

--- a/src/backlight/metrics/evaluation_metrics.py
+++ b/src/backlight/metrics/evaluation_metrics.py
@@ -43,9 +43,7 @@ def calculate_sharpe(
     """
     value = positions_or_portfolio.value.resample(freq).first().dropna()
     previous_value = value.shift(periods=1)
-    pl = (value.values / previous_value.values)[1:]
-    pl = pl[pl > 0]
-    log_return = np.log(pl)
+    log_return = np.log((value.values / previous_value.values)[1:])
 
     days_in_year = pd.Timedelta("252D")
     annual_factor = math.sqrt(days_in_year / freq)

--- a/src/backlight/portfolio/portfolio.py
+++ b/src/backlight/portfolio/portfolio.py
@@ -157,10 +157,8 @@ def _bfill_principal(position: Positions, index: pd.DatetimeIndex) -> Positions:
         index=index,
         columns=position.columns,
     )
-    filled_positions.principal.iloc[:] = position.principal[
-        position.principal.first_valid_index()
-    ]
     filled_positions.loc[position.index] = position
+    filled_positions.principal = filled_positions.principal.replace(to_replace=0, method='bfill')
     return backlight.positions.positions.from_dataframe(
         filled_positions, position.symbol, position.currency_unit
     )

--- a/src/backlight/portfolio/portfolio.py
+++ b/src/backlight/portfolio/portfolio.py
@@ -158,7 +158,9 @@ def _bfill_principal(position: Positions, index: pd.DatetimeIndex) -> Positions:
         columns=position.columns,
     )
     filled_positions.loc[position.index] = position
-    filled_positions.principal = filled_positions.principal.replace(to_replace=0, method='bfill')
+    filled_positions.principal = filled_positions.principal.replace(
+        to_replace=0, method="bfill"
+    )
     return backlight.positions.positions.from_dataframe(
         filled_positions, position.symbol, position.currency_unit
     )


### PR DESCRIPTION
I observed some default in results, such as nan Sharpe values or big gap in positions values. Both of them came from the fusion of positions index. I fixed it here.