### PR TITLE
Revert strategies/exit.py (#89) as observing slow exit_by_trailing_stop.

### DIFF
--- a/src/backlight/__init__.py
+++ b/src/backlight/__init__.py
@@ -1,4 +1,4 @@
 __author__ = "AlpacaJapan Co., Ltd."
-__version__ = "1.0.6"
-__release__ = "1.0.6"
+__version__ = "1.0.7"
+__release__ = "1.0.7"
 __license__ = "MIT"

--- a/src/backlight/strategies/exit.py
+++ b/src/backlight/strategies/exit.py
@@ -80,7 +80,7 @@ def exit(
 
         df = pd.DataFrame(index=indices, data=exits, columns=["amount", "_id"])
 
-        return from_dataframe(df, entries.symbol, trades.currency_unit)
+        return from_dataframe(df, trades.symbol, trades.currency_unit)
 
     exits = _exit(entries, df, exit_condition)
     return concat([entries, exits])
@@ -128,7 +128,7 @@ def exit_by_max_holding_time(
             exits.append((transaction.amount, i))
 
         df = pd.DataFrame(index=indices, data=exits, columns=["amount", "_id"])
-        return from_dataframe(df, entries.symbol, trades.currency_unit)
+        return from_dataframe(df, trades.symbol, trades.currency_unit)
 
     exits = _exit_by_max_holding_time(entries, df, max_holding_time, exit_condition)
     return concat([entries, exits])


### PR DESCRIPTION
exit_by_trailing_stop with market data for a day becomes slower than before.
Sorry for no benchmark results attached.