### PR TITLE
Avoid an error of calculate_trade_performance with same timestamp records in a trade

### DIFF
--- a/src/backlight/metrics/trade_metrics.py
+++ b/src/backlight/metrics/trade_metrics.py
@@ -22,7 +22,6 @@ def _sum(a: pd.Series) -> float:
 
 def _calculate_pl(trade: pd.Series, mkt: MarketData) -> float:
     mkt = mkt.loc[trade.index.unique(), :]
-
     trades = make_trades(mkt.symbol, [trade], mkt.currency_unit)
     positions = backlight.positions.calculate_positions(trades, mkt)
     pl = calculate_pl(positions)

--- a/src/backlight/metrics/trade_metrics.py
+++ b/src/backlight/metrics/trade_metrics.py
@@ -21,7 +21,12 @@ def _sum(a: pd.Series) -> float:
 
 
 def _calculate_pl(trade: pd.Series, mkt: MarketData) -> float:
-    mkt = mkt.loc[trade.index, :]
+    if len(trade.index.unique()) == 1:
+        # to avoid reindex error in later process
+        mkt = mkt.loc[trade.index[0] : trade.index[-1], :]
+    else:
+        mkt = mkt.loc[trade.index, :]
+
     trades = make_trades(mkt.symbol, [trade], mkt.currency_unit)
     positions = backlight.positions.calculate_positions(trades, mkt)
     pl = calculate_pl(positions)

--- a/src/backlight/metrics/trade_metrics.py
+++ b/src/backlight/metrics/trade_metrics.py
@@ -21,11 +21,7 @@ def _sum(a: pd.Series) -> float:
 
 
 def _calculate_pl(trade: pd.Series, mkt: MarketData) -> float:
-    if len(trade.index.unique()) == 1:
-        # to avoid reindex error in later process
-        mkt = mkt.loc[trade.index[0] : trade.index[-1], :]
-    else:
-        mkt = mkt.loc[trade.index, :]
+    mkt = mkt.loc[trade.index.unique(), :]
 
     trades = make_trades(mkt.symbol, [trade], mkt.currency_unit)
     positions = backlight.positions.calculate_positions(trades, mkt)


### PR DESCRIPTION
same timestamp records in a trade causes an error of calculate_trade_performance.